### PR TITLE
Add option flag to make output always show positions.

### DIFF
--- a/AGEaligner.cpp
+++ b/AGEaligner.cpp
@@ -66,14 +66,15 @@ bool AGEaligner::align(Scorer &scr,int flag)
 {
   _n_bpoints = 0; // Erase previous break points
   if (_len1 <= 0 || _len2 <= 0) return false;
-  if (!(flag & ALL_FLAGS)) return false;
+  if (!(flag & ALL_MODES)) return false;
 
   // Deciding on whether need to use auxiliary aligner
   int aux_flag = 0;
-  _flag = flag;
+  _flag = flag & ALL_MODES;
+  _disp_opts = flag & ALL_DISP_OPTS;
   if (flag & INVERSION_FLAG) {
     _flag    = INVL_FLAG;
-    aux_flag = INVR_FLAG;
+    aux_flag = INVR_FLAG | _disp_opts;
   }
 
 #ifdef AGE_TIME
@@ -276,14 +277,14 @@ void AGEaligner::printAlignment()
       cout<<" first  seq => ";
       len = abs(s - e - inc1);
       cout<<setw(9)<<len<<" nucs";
-      if (len > 0) cout<<" ["<<s<<","<<e<<"]";
+      if (len > 0 || _disp_opts & SHOW_ALL_POS) cout<<" ["<<s<<","<<e<<"]";
       cout<<endl;
       cout<<" second seq => ";
       s = f->end2() + inc2;
       e = f->next()->start2() - inc2;
       len = abs(s - e - inc2);
       cout<<setw(9)<<len<<" nucs";
-      if (len > 0) cout<<" ["<<s<<","<<e<<"]";
+      if (len > 0 || _disp_opts & SHOW_ALL_POS) cout<<" ["<<s<<","<<e<<"]";
       cout<<endl;
     }
 
@@ -296,14 +297,14 @@ void AGEaligner::printAlignment()
 	cout<<" first  seq => ";
 	len = abs(s - e - inc1);
 	cout<<setw(9)<<len<<" nucs";
-	if (len > 0) cout<<" ["<<s<<","<<e<<"]";
+	if (len > 0 || _disp_opts & SHOW_ALL_POS) cout<<" ["<<s<<","<<e<<"]";
 	cout<<endl;
 	cout<<" second seq => ";
 	s = f->end2() + inc2;
 	e = f->next()->start2() - inc2;
 	len = abs(s - e - inc2);
 	cout<<setw(9)<<len<<" nucs";
-	if (len > 0) cout<<" ["<<s<<","<<e<<"]";
+	if (len > 0 || _disp_opts & SHOW_ALL_POS) cout<<" ["<<s<<","<<e<<"]";
 	cout<<endl;
       }
       break;
@@ -317,7 +318,7 @@ void AGEaligner::printAlignment()
       int bp1 = inc1*(s - _s1.start()), bp2 = inc1*(e - _s1.start());
       int n_hom = calcIdentity(_seq1,bp1,bp2,left,right);
       cout<<" first  seq => "<<setw(9)<<n_hom<<" nucs";
-      if (n_hom > 0)
+      if (n_hom > 0 || _disp_opts & SHOW_ALL_POS)
 	cout<<" ["<<s + inc1*left<<","<<s + inc1*(right - 1)<<"] to"
 	    <<" ["<<e + inc1*left<<","<<e + inc1*(right - 1)<<"]";
       cout<<endl;
@@ -325,7 +326,7 @@ void AGEaligner::printAlignment()
       bp1 = inc2*(s - _s2.start()), bp2 = inc2*(e - _s2.start());
       n_hom = calcIdentity(_seq2,bp1,bp2,left,right);
       cout<<" second seq => "<<setw(9)<<n_hom<<" nucs";
-      if (n_hom > 0)
+      if (n_hom > 0 || _disp_opts & SHOW_ALL_POS)
 	cout<<" ["<<s + inc2*left<<","<<s + inc2*(right - 1)<<"] to"
 	    <<" ["<<e + inc2*left<<","<<e + inc2*(right - 1)<<"]";
       cout<<endl;
@@ -337,7 +338,7 @@ void AGEaligner::printAlignment()
       int bp1 = inc1*(s - _s1.start()), bp2 = inc1*(e - _s1.start());
       int n_hom = calcOutsideIdentity(_seq1,bp1,bp2);
       cout<<" first  seq => "<<setw(9)<<n_hom<<" nucs";
-      if (n_hom > 0)
+      if (n_hom > 0 || _disp_opts & SHOW_ALL_POS)
 	cout<<" ["<<s - inc1*(n_hom - 1)<<","<<s<<"] to"
 	    <<" ["<<e<<","<<e + inc1*(n_hom - 1)<<"]";
       cout<<endl;
@@ -345,7 +346,7 @@ void AGEaligner::printAlignment()
       bp1 = inc2*(s - _s2.start()), bp2 = inc2*(e - _s2.start());
       n_hom = calcOutsideIdentity(_seq2,bp1,bp2);
       cout<<" second seq => "<<setw(9)<<n_hom<<" nucs";
-      if (n_hom > 0)
+      if (n_hom > 0 || _disp_opts & SHOW_ALL_POS)
 	cout<<" ["<<s - inc2*(n_hom - 1)<<","<<s<<"] to"
 	    <<" ["<<e<<","<<e + inc2*(n_hom - 1)<<"]";
       cout<<endl;
@@ -357,7 +358,7 @@ void AGEaligner::printAlignment()
       int bp1 = inc1*(s - _s1.start()), bp2 = inc1*(e - _s1.start());
       int n_hom = calcInsideIdentity(_seq1,bp1,bp2);
       cout<<" first  seq => "<<setw(9)<<n_hom<<" nucs";
-      if (n_hom > 0)
+      if (n_hom > 0 || _disp_opts & SHOW_ALL_POS)
 	cout<<" ["<<s<<","<<s + inc1*(n_hom - 1)<<"] to"
 	    <<" ["<<e - inc1*(n_hom - 1)<<","<<e<<"]";
       cout<<endl;
@@ -365,7 +366,7 @@ void AGEaligner::printAlignment()
       bp1 = inc2*(s - _s2.start()), bp2 = inc2*(e - _s2.start());
       n_hom = calcInsideIdentity(_seq2,bp1,bp2);
       cout<<" second seq => "<<setw(9)<<n_hom<<" nucs";
-      if (n_hom > 0)
+      if (n_hom > 0 || _disp_opts & SHOW_ALL_POS)
 	cout<<" ["<<s<<","<<s + inc2*(n_hom - 1)<<"] to"
 	    <<" ["<<e - inc2*(n_hom - 1)<<","<<e<<"]";
       cout<<endl;

--- a/AGEaligner.hh
+++ b/AGEaligner.hh
@@ -74,9 +74,11 @@ public:
   const static int INVERSION_FLAG    = 0x04;
   const static int INVR_FLAG         = 0x08;
   const static int INVL_FLAG         = 0x10;
+  const static int SHOW_ALL_POS      = 0x20;
 private:
-  const static int ALL_FLAGS         = INDEL_FLAG | TDUPLICATION_FLAG |
+  const static int ALL_MODES         = INDEL_FLAG | TDUPLICATION_FLAG |
     INVERSION_FLAG | INVR_FLAG | INVL_FLAG;
+  const static int ALL_DISP_OPTS     = SHOW_ALL_POS;
 
 private:
   Sequence       &_s1,  *_s1_rc,  &_s2;    // Sequences with headers
@@ -88,6 +90,7 @@ private:
   int            score_n1, score_n2;       // Dimensions of scoring matrices
   long           score_size;               // Size of scoring matrices
   int            _flag;                    // Flag defining alignment mode
+  int            _disp_opts;               // Flag defining display options
   AGEaligner     *_aux_aligner;            // Auxilary aligner
 
   // Coordiantes of the excised retion: left1, left2, right1, right2

--- a/README
+++ b/README
@@ -70,7 +70,7 @@ Options:
 -mismatch		score for nucleotide mismatch
 -go=value		gap open penalty, negative value
 -ge=value		gap extend penalty, negative value
-
+-allpos			always display boundary positions
 
 Examples:
 

--- a/age_align.cpp
+++ b/age_align.cpp
@@ -97,7 +97,7 @@ int main(int argc,char *argv[])
   string usage = "Usage:\n\t";
   usage += exe; usage += "\n";
   sout.str("");sout<<DEFAULT_MATCH;
-  usage += "\t\t[-version]\n";
+  usage += "\t\t[-version] [-allpos]\n";
   usage += "\t\t[-indel|-tdup|-inv|-invl|-invr]\n";
   usage += "\t\t[-match=value:"; usage += sout.str(); usage += "]";
   sout.str("");sout<<DEFAULT_MISMATCH;
@@ -221,6 +221,8 @@ int main(int argc,char *argv[])
 	  }
 	} else if (option == "-version") {
 	  version = true;
+	} else if (option == "-allpos") {
+	  flag |= AGEaligner::SHOW_ALL_POS;
 	} else if (option == "-indel") {
 	  flag |= AGEaligner::INDEL_FLAG;
 	} else if (option == "-inv") {
@@ -263,8 +265,6 @@ int main(int argc,char *argv[])
       return 0;
     }
 
-    if (flag == 0) flag = AGEaligner::INDEL_FLAG;
-
     int n_modes = 0;
     if (flag & AGEaligner::INDEL_FLAG)        n_modes++;
     if (flag & AGEaligner::TDUPLICATION_FLAG) n_modes++;
@@ -272,12 +272,10 @@ int main(int argc,char *argv[])
     if (flag & AGEaligner::INVL_FLAG)         n_modes++;
     if (flag & AGEaligner::INVERSION_FLAG)    n_modes++;
 
-    if (n_modes != 1) {
-      cerr<<"Error in mode specification. ";
-      if (n_modes == 0)
-	cerr<<"No mode is specified."<<endl;
-      if (n_modes > 1)
-	cerr<<"More than one mode is specified."<<endl;
+    if (n_modes == 0)
+      flag |= AGEaligner::INDEL_FLAG;
+    if (n_modes > 1) {
+      cerr<<"Error: More than one mode is specified."<<endl;
       error = true;
     }
 

--- a/test.sh
+++ b/test.sh
@@ -4,81 +4,81 @@ echo "* Test #1"
 echo "For alignment with large deletion and micro insersion. Mismatches"
 echo "and small deletions are present in each flanking sequence."
 echo "Run as: ./age_align test1_*.fa"
-./age_align test1_*.fa
+./age_align test1_*.fa "$@"
 
 echo "* Test #2"
 echo "For alignment with same size deletion and insersion."
 echo "Run as: ./age_align test2_*.fa"
-./age_align test2_*.fa
+./age_align test2_*.fa "$@"
 
 echo "* Test #3"
 echo "For alignment with large deletion, insersion and microhomology around"
 echo "breakpoints."
 echo "Run as: ./age_align test3_*.fa"
-./age_align test3_*.fa
+./age_align test3_*.fa "$@"
 
 echo "* Test #4"
 echo "Another test for homology around breakpoints."
 echo "Run as: ./age_align test4_*.fa"
-./age_align test4_*.fa
+./age_align test4_*.fa "$@"
 
 echo "* Test #5"
 echo "For microhomology inside and outside breakpoints."
 echo "Run as: ./age_align test5_*.fa"
-./age_align test5_*.fa
+./age_align test5_*.fa "$@"
 
 echo "* Test #6"
 echo "For an alternative alignment. There is a 2 bp homology at breakpoints."
 echo "No alternative should be reported."
 echo "Run as: ./age_align test6_*.fa"
-./age_align test6_*.fa
+./age_align test6_*.fa "$@"
 
 echo "* Test #7"
 echo "For an alternative alignment. Right flanking sequence aligns at a"
 echo "different place."
 echo "Run as: ./age_align test7_*.fa"
-./age_align test7_*.fa
+./age_align test7_*.fa "$@"
 
 echo "* Test #8"
 echo "Test for an alignment of reverse complement (second sequence)."
 echo "Run as: ./age_align test8_*.fa -revcom2"
-./age_align test8_*.fa -revcom2
+./age_align test8_*.fa -revcom2 "$@"
 
 echo "* Test #9"
 echo "Test for alignment with many indels/mismatches in flanking sequences."
 echo "Run as: ./age_align test9_*.fa"
-./age_align test9_*.fa
+./age_align test9_*.fa "$@"
 
 echo "* Test #10"
 echo "Test for inversion."
 echo "Run as: ./age_align test10_*.fa -inv"
-./age_align test10_*.fa -inv
+./age_align test10_*.fa -inv "$@"
 
 echo "* Test #11"
 echo "Test for inversion."
 echo "Run as: ./age_align test11_*.fa -inv"
-./age_align test11_*.fa -inv
+./age_align test11_*.fa -inv "$@"
 
 echo "* Test #12"
 echo "Test to demonstrate that linear pass to find optimal split between two"
 echo "local alignments won't find correct alginment. This case is put in the"
 echo "paper (Abyzov & Gerstein, 2011)."
 echo "Run as: ./age_align test12_*.fa -match=1 -mismatch=-2 -go=-4 -ge=-2"
-./age_align test12_*.fa -match=1 -mismatch=-2 -go=-4 -ge=-2
+./age_align test12_*.fa -match=1 -mismatch=-2 -go=-4 -ge=-2 "$@"
 
 echo "* Test #13"
 echo "Test for tandem duplication."
 echo "Run as: ./age_align test13_*.fa -tdup"
-./age_align test13_*.fa -tdup
+./age_align test13_*.fa -tdup "$@"
 
 echo "* Test #14"
 echo "Inversion with conting over left breakpoint."
 echo "Run as: ./age_align test14_*.fa -inv"
-./age_align test14_*.fa -inv
+./age_align test14_*.fa -inv "$@"
 
 echo "* Test #15"
 echo "Inversion with conting over right breakpoint."
 echo "Run as: ./age_align test15_*.fa -inv"
-./age_align test15_*.fa -inv
+./age_align test15_*.fa -inv "$@"
 
 exit 0;


### PR DESCRIPTION
Current AGE output hides boundary positions when interval lengths are zero. However, certain downstream applications may benefit from extracting those positions, especially identities across sequences. This PR introduces a command line flag `-allpos` that makes AGE always print interval boundaries. The formatting of the output is not changed in any way, and this PR has no effect when `-allpos` is not specified.
